### PR TITLE
Unify signature of PyFloat_FromString

### DIFF
--- a/doc/source/cheatsheet.rst
+++ b/doc/source/cheatsheet.rst
@@ -28,6 +28,13 @@ Ints
 Use whatever you used in Python 2. For py3-only code, use ``PyLong``.
 
 
+Floats
+~~~~~~
+
+Don't pass the useless second argument to PyFloat_FromString as you needed
+to do in Python 2.
+
+
 Comparisons
 ~~~~~~~~~~~
 

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -389,6 +389,17 @@ All follow the Python 2 API.
     | Python 2: :c:func:`(provided) <py2:PyInt_AsSsize_t>`
     | Python 3: :c:func:`PyLong_AsSsize_t <py3:PyLong_AsSsize_t>`
 
+PyFloat
+~~~~~~~
+
+.. c:function:: PyObject* PyFloat_FromString(PyObject *str)
+
+    Create a :c:type:`PyFloatObject` object.  The signature has been
+    adapted to follow the Python 3 API.
+
+    | Python 2: :c:func:`PyFloat_FromString(str, NULL) <py2:PyFloat_FromString>`
+    | Python 3: :c:func:`PyFloat_FromString(str) <py3:PyFloat_FromString>`
+
 
 Module Initialization
 ~~~~~~~~~~~~~~~~~~~~~

--- a/include/py3c/compat.h
+++ b/include/py3c/compat.h
@@ -105,6 +105,10 @@ static inline PyObject *PyStr_Concat(PyObject *left, PyObject *right) {
 #define PyBytes_ConcatAndDel PyString_ConcatAndDel
 #define _PyBytes_Resize _PyString_Resize
 
+/* Floats */
+
+#define PyFloat_FromString(str) PyFloat_FromString(str, NULL)
+
 /* Module init */
 
 #define PyModuleDef_HEAD_INIT 0

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -136,6 +136,12 @@ class IntChecks(TestCase):
         self.assertTrue(test_py3c.int_asssize_t_check(8))
 
 
+class FloatChecks(TestCase):
+    def test_fromstring(self):
+        self.assertEqual(test_py3c.float_fromstring('42'), 42.0)
+        self.assertEqual(test_py3c.float_fromstring('-10.5'), -10.5)
+
+
 class TypeChecks(TestCase):
     def test_return_notimplemented(self):
         self.assertIs(test_py3c.return_notimplemented(), NotImplemented)

--- a/test/test_py3c.c
+++ b/test/test_py3c.c
@@ -135,6 +135,11 @@ static PyObject *int_asssize_t_check(PyObject *mod, PyObject * o) {
 }
 
 
+static PyObject *float_fromstring(PyObject *mod, PyObject *o) {
+	return PyFloat_FromString(o);
+}
+
+
 static PyObject *return_notimplemented(PyObject *mod) {
 	Py_RETURN_NOTIMPLEMENTED;
 }
@@ -338,6 +343,8 @@ static PyMethodDef methods[] = {
 	FUNC(METH_O, int_aslong_macro_check),
 	FUNC(METH_O, int_asunsignedlonglongmask_check),
 	FUNC(METH_O, int_asssize_t_check),
+
+    FUNC(METH_O, float_fromstring),
 
 	FUNC(METH_NOARGS, return_notimplemented),
 


### PR DESCRIPTION
The useless second parameter of PyFloat_FromString has been removed in
the Python 3 API. This patch adapts the signature to become the same in
Python 2.