### PR TITLE
Fix $(realpath ...) substitution on OSX.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,10 @@ test-%: build-%
 test-%-cpp: build-%-cpp
 	TEST_USE_CPP=yes PYTHONPATH=$(wildcard test/build/lib*) $* test -v
 
-py3c.pc: py3c.pc.in
+$(includedir):
+	mkdir -p $(includedir)
+
+py3c.pc: py3c.pc.in $(includedir)
 	sed -e's:@includedir@:$(realpath $(includedir)):' $< > $@
 
 install: py3c.pc


### PR DESCRIPTION
On OSX, if the target path does not exist, `$(realpath $(includedir))` will return an empty string, which makes the pkg-config template somewhat useless.

This change ensures that the path exists before the template is substituted.