### PR TITLE
Backport features from 3.7

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -7,6 +7,14 @@ py3c Changes
 Version History
 ===============
 
+v1.0 (upcoming)
+-----------------
+
+Additions:
+
+* Add Py_UNREACHABLE from Python 3.7
+
+
 v0.9 (2017-11-08)
 -----------------
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -14,6 +14,7 @@ Additions:
 
 * Add Py_UNREACHABLE from Python 3.7
 * Add Py_RETURN_RICHCOMPARE from Python 3.7
+* Add Py_UNUSED from Python 3.4
 
 Deprecations:
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -13,6 +13,12 @@ v1.0 (upcoming)
 Additions:
 
 * Add Py_UNREACHABLE from Python 3.7
+* Add Py_RETURN_RICHCOMPARE from Python 3.7
+
+Deprecations:
+
+* The macro PY3C_RICHCMP is deprecated in favor of Py_RETURN_RICHCOMPARE.
+  There are no plans to remove the old macro from py3c.
 
 
 v0.9 (2017-11-08)

--- a/doc/source/cheatsheet.rst
+++ b/doc/source/cheatsheet.rst
@@ -43,7 +43,7 @@ Use `rich comparisons <https://www.python.org/dev/peps/pep-0207/>`_::
     static PyObject* mytype_richcmp(PyObject *obj1, PyObject *obj2, int op)
     {
         if (mytype_Check(obj2)) {
-            return PY3C_RICHCMP(get_data(obj1), get_data(obj2), op);
+            PY_RETURN_RICHCOMPARE(get_data(obj1), get_data(obj2), op);
         }
         Py_RETURN_NOTIMPLEMENTED;
     }

--- a/doc/source/defs.rst
+++ b/doc/source/defs.rst
@@ -38,6 +38,7 @@ PyVarObject_HEAD_INIT        ✔             ✔
 PyCapsule_*                  see below     ✔
 Py_TPFLAGS_*                 ✔             see below
 PyMem_Raw*                   =             =
+Py_UNUSED                    =             =
 ============================ ============= ==============
 
 Legend:

--- a/doc/source/defs.rst
+++ b/doc/source/defs.rst
@@ -29,6 +29,7 @@ MODULE_INIT_FUNC             see below     see below
 Rich comparisons             ✔             ✔
 PY3C_RICHCMP                 see below     see below
 Py_RETURN_NOTIMPLEMENTED     =             =
+Py_UNREACHABLE               =             =
 Py_TYPE                      ✔             ✔
 Py_REFCNT                    ✔             ✔
 Py_SIZE                      ✔             ✔
@@ -42,7 +43,7 @@ Legend:
 
     | ✔ – provided by Python
     | → – defined in py3c as a simple alias for
-    | = – provided by at least Python 3.5; py3c backports it to Python versions that don't define it
+    | = – provided by at least Python 3.7; py3c backports it to Python versions that don't define it
 
 The following non-trivial macros are defined:
 

--- a/doc/source/defs.rst
+++ b/doc/source/defs.rst
@@ -27,9 +27,10 @@ PyModuleDef_HEAD_INIT        → 0           ✔
 PyModule_Create              see below     ✔
 MODULE_INIT_FUNC             see below     see below
 Rich comparisons             ✔             ✔
-PY3C_RICHCMP                 see below     see below
+Py_RETURN_RICHCOMPARE        =             =
 Py_RETURN_NOTIMPLEMENTED     =             =
 Py_UNREACHABLE               =             =
+PY3C_RICHCMP                 see below     see below
 Py_TYPE                      ✔             ✔
 Py_REFCNT                    ✔             ✔
 Py_SIZE                      ✔             ✔
@@ -68,7 +69,8 @@ The following non-trivial macros are defined:
         | Python 2: declares & defines init<mod>; declares a static PyInit_<mod> and provides function header for it
 
     :c:func:`PY3C_RICHCMP`
-        | See :c:func:`docs <PY3C_RICHCMP>`. (Purely a convenience macro, same in both versions.)
+        | Convenience macro for comparisons, same in both versions.
+        | Deprecated; use :c:macro:`Py_RETURN_RICHCOMPARE` instead.
 
     :ref:`PyCapsule_* <capsulethunk>`
         | Capsules are included in Python 2.7 and 3.1+.

--- a/doc/source/guide-cleanup.rst
+++ b/doc/source/guide-cleanup.rst
@@ -45,10 +45,14 @@ In other words, remove the ``py3c.h`` header, and fix the compile errors.
 *   .. index::
         double: Cleanup; Comparisons
 
-    Replace PY3C_RICHCMP by its expansion, unless you keep the ``py3c/comparison.h``
-    header.
+    Replace ``return PY3C_RICHCMP`` by :c:func:`Py_RETURN_RICHCOMPARE`,
+    as mentioned in :c:macro:`PY3C_RICHCMP` documentation.
 
-*   Replace Py_RETURN_NOTIMPLEMENTED by its expansion, unless you either
+*   Replace :c:func:`Py_RETURN_RICHCOMPARE` and :c:func:`Py_UNREACHABLE`
+    by its expansion, unless you either
+    support Python 3.7+ only or keep the ``py3c/comparison.h`` header.
+
+*   Replace :c:func:`Py_RETURN_NOTIMPLEMENTED` by its expansion, unless you either
     support Python 3.3+ only or keep the ``py3c/comparison.h`` header.
 
 *   Drop ``capsulethunk.h``, if you're using it.

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -474,23 +474,38 @@ Comparison Helpers
     Backported from :c:macro:`Python 3.7 <py3:Py_UNREACHABLE>`
     for older versions.
 
-.. c:function:: PyObject* PY3C_RICHCMP(val1, val2, int op)
+.. c:function:: PyObject* PY_RETURN_RICHCOMPARE(val1, val2, int op)
 
     Compares two arguments orderable by C comparison operators (such as C
-    ints or floats). The third argument specifies the requested operation,
+    ints or floats), and returns :c:data:`Py_True` or :c:data:`Py_False` based
+    on the result, properly increasing the reference count.
+
+    The third argument specifies the requested operation,
     as for a :c:member:`rich comparison function <py3:PyTypeObject.tp_richcompare>`.
-    Evaluates to a new reference to ``Py_True`` or ``Py_False``, depending
-    on the result of the comparison.
 
-    ::
+    Backported from :c:macro:`Python 3.7 <py3:PY_RETURN_RICHCOMPARE>`
+    for older versions.
 
-        ((op) == Py_EQ) ? PyBool_FromLong((val1) == (val2)) : \
-        ((op) == Py_NE) ? PyBool_FromLong((val1) != (val2)) : \
-        ((op) == Py_LT) ? PyBool_FromLong((val1) < (val2)) : \
-        ((op) == Py_GT) ? PyBool_FromLong((val1) > (val2)) : \
-        ((op) == Py_LE) ? PyBool_FromLong((val1) <= (val2)) : \
-        ((op) == Py_GE) ? PyBool_FromLong((val1) >= (val2)) : \
-        (Py_INCREF(Py_NotImplemented), Py_NotImplemented)
+.. c:function:: PyObject* PY3C_RICHCMP(val1, val2, int op)
+
+    .. deprecated:: 1.0
+        Use :c:func:`PY_RETURN_RICHCOMPARE` instead
+
+    A helper for rich comparisons that py3c provided before such a helper was,
+    with slightly changed name and semantics,
+    `included in Python itself <https://bugs.python.org/issue23699>`_.
+
+    There are no plans to remove :c:macro:`PY3C_RICHCMP` from py3c,
+    but before *your project* gets rid of py3c, all calls need to switch
+    to what's provided by CPython.
+
+    To switch, instead of::
+
+        return PY3C_RICHCMP(a, b, op)
+
+    write::
+
+        PY_RETURN_RICHCOMPARE(a, b, op)
 
 
 Types

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -466,6 +466,14 @@ Comparison Helpers
     Backported from :c:macro:`Python 3.4 <py3:Py_RETURN_NOTIMPLEMENTED>`
     for older versions.
 
+.. c:macro:: Py_UNREACHABLE
+
+    Use instead of `assert()` or `abort()` in unreachable code,
+    such as handling undefined comparison operations.
+
+    Backported from :c:macro:`Python 3.7 <py3:Py_UNREACHABLE>`
+    for older versions.
+
 .. c:function:: PyObject* PY3C_RICHCMP(val1, val2, int op)
 
     Compares two arguments orderable by C comparison operators (such as C

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -668,3 +668,14 @@ except they return unique pointers when zero bytes are requested.
 
     Backport of :c:func:`py3:PyMem_Calloc` from Python 3.5+.
     Replacement for ``calloc``.
+
+
+Unused Arguments
+~~~~~~~~~~~~~~~~
+
+.. c:macro:: Py_UNUSED(arg)
+
+    Use this for unused arguments in a function definition to silence compiler
+    warnings, e.g. ``PyObject* func(PyObject *Py_UNUSED(ignored))``.
+
+    Backport of :c:macro:`py3:Py_UNUSED` from Python 3.4+.

--- a/include/py3c/comparison.h
+++ b/include/py3c/comparison.h
@@ -13,6 +13,10 @@
     return Py_INCREF(Py_NotImplemented), Py_NotImplemented
 #endif
 
+#ifndef Py_UNREACHABLE
+#define Py_UNREACHABLE() abort()
+#endif
+
 #define PY3C_RICHCMP(val1, val2, op) \
     ((op) == Py_EQ) ? PyBool_FromLong((val1) == (val2)) : \
     ((op) == Py_NE) ? PyBool_FromLong((val1) != (val2)) : \

--- a/include/py3c/comparison.h
+++ b/include/py3c/comparison.h
@@ -17,6 +17,22 @@
 #define Py_UNREACHABLE() abort()
 #endif
 
+#ifndef Py_RETURN_RICHCOMPARE
+#define Py_RETURN_RICHCOMPARE(val1, val2, op)                               \
+    do {                                                                    \
+        switch (op) {                                                       \
+        case Py_EQ: if ((val1) == (val2)) Py_RETURN_TRUE; Py_RETURN_FALSE;  \
+        case Py_NE: if ((val1) != (val2)) Py_RETURN_TRUE; Py_RETURN_FALSE;  \
+        case Py_LT: if ((val1) < (val2)) Py_RETURN_TRUE; Py_RETURN_FALSE;   \
+        case Py_GT: if ((val1) > (val2)) Py_RETURN_TRUE; Py_RETURN_FALSE;   \
+        case Py_LE: if ((val1) <= (val2)) Py_RETURN_TRUE; Py_RETURN_FALSE;  \
+        case Py_GE: if ((val1) >= (val2)) Py_RETURN_TRUE; Py_RETURN_FALSE;  \
+        default:                                                            \
+            Py_UNREACHABLE();                                               \
+        }                                                                   \
+    } while (0)
+#endif
+
 #define PY3C_RICHCMP(val1, val2, op) \
     ((op) == Py_EQ) ? PyBool_FromLong((val1) == (val2)) : \
     ((op) == Py_NE) ? PyBool_FromLong((val1) != (val2)) : \

--- a/include/py3c/py3shims.h
+++ b/include/py3c/py3shims.h
@@ -3,7 +3,7 @@
  */
 
 /*
- * Shims for the  PyMem_Raw* functions added inPython 3.3
+ * Shims for new functionality from in Python 3.3+
  *
  * See https://docs.python.org/3/c-api/memory.html#raw-memory-interface
  */
@@ -14,12 +14,27 @@
 #include <stdlib.h>
 
 
+/* Py_UNUSED - added in Python 3.4, documneted in 3.7 */
+
+#ifndef Py_UNUSED
+#ifdef __GNUC__
+#define Py_UNUSED(name) _unused_ ## name __attribute__((unused))
+#else
+#define Py_UNUSED(name) _unused_ ## name
+#endif
+#endif
+
+
+/* PyMem_Raw{Malloc,Realloc,Free} - added in Python 3.4 */
+
 #if PY_MAJOR_VERSION < 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 4)
 #define PyMem_RawMalloc(n) malloc((n) || 1)
 #define PyMem_RawRealloc(p, n) realloc(p, (n) || 1)
 #define PyMem_RawFree(p) free(p)
 #endif /* version < 3.4 */
 
+
+/* PyMem_RawCalloc - added in Python 3.5 */
 
 #if PY_MAJOR_VERSION < 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 5)
 #define PyMem_RawCalloc(n, s) calloc((n) || 1, (s) || 1)

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -143,34 +143,46 @@ class FloatChecks(TestCase):
         self.assertEqual(test_py3c.float_fromstring('-10.5'), -10.5)
 
 
-class TypeChecks(TestCase):
+class ComparisonHelperChecks(TestCase):
     def test_return_notimplemented(self):
         self.assertIs(test_py3c.return_notimplemented(), NotImplemented)
 
+    def test_unreachable(self):
+        proc = subprocess.Popen(
+            [sys.executable, '-c',
+             'import test_py3c; test_py3c.test_unreachable()'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
+        self.assertEqual(stdout, b'')
+        self.assertEqual(stderr, b'')
+        self.assertNotEqual(proc.returncode, 0)
+
+
+class ComparisonChecksBase(object):
     def test_number(self):
-        num = test_py3c.Number(3)
+        num = self.cls(3)
         self.assertEqual(num.value, 3)
         num.value = 5
         self.assertEqual(num.value, 5)
 
     def test_number_number_equality(self):
-        three = test_py3c.Number(3)
-        three2 = test_py3c.Number(3)
-        five = test_py3c.Number(5)
+        three = self.cls(3)
+        three2 = self.cls(3)
+        five = self.cls(5)
         self.assertEqual(three, three)
         self.assertEqual(three, three2)
         self.assertNotEqual(three, five)
 
     def test_number_int_equality(self):
-        three = test_py3c.Number(3)
-        five = test_py3c.Number(5)
+        three = self.cls(3)
+        five = self.cls(5)
         self.assertEqual(three, 3)
         self.assertNotEqual(three, 5)
 
     def test_all_comparisons(self):
-        three = test_py3c.Number(3)
-        three2 = test_py3c.Number(3)
-        five = test_py3c.Number(5)
+        three = self.cls(3)
+        three2 = self.cls(3)
+        five = self.cls(5)
         for op in (operator.eq, operator.ne, operator.gt, operator.lt,
                    operator.ge, operator.le):
             self.assertEqual(op(three, three), op(3, 3))
@@ -183,15 +195,14 @@ class TypeChecks(TestCase):
             self.assertEqual(op(three, 5), op(3, 5))
             self.assertEqual(op(5, three), op(5, 3))
 
-    def test_unreachable(self):
-        proc = subprocess.Popen(
-            [sys.executable, '-c',
-             'import test_py3c; test_py3c.test_unreachable()'],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = proc.communicate()
-        self.assertEqual(stdout, b'')
-        self.assertEqual(stderr, b'')
-        self.assertNotEqual(proc.returncode, 0)
+
+
+class OldComparisonChecks(TestCase, ComparisonChecksBase):
+    cls = test_py3c.OldNumber
+
+
+class NewComparisonChecks(TestCase, ComparisonChecksBase):
+    cls = test_py3c.NewNumber
 
 
 class CapsuleChecks(TestCase):

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -7,6 +7,7 @@ import gc
 import tempfile
 import os
 import shutil
+import subprocess
 
 import test_py3c
 
@@ -181,6 +182,16 @@ class TypeChecks(TestCase):
             self.assertEqual(op(3, three), op(3, 3))
             self.assertEqual(op(three, 5), op(3, 5))
             self.assertEqual(op(5, three), op(5, 3))
+
+    def test_unreachable(self):
+        proc = subprocess.Popen(
+            [sys.executable, '-c',
+             'import test_py3c; test_py3c.test_unreachable()'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
+        self.assertEqual(stdout, b'')
+        self.assertEqual(stderr, b'')
+        self.assertNotEqual(proc.returncode, 0)
 
 
 class CapsuleChecks(TestCase):

--- a/test/test_py3c.c
+++ b/test/test_py3c.c
@@ -395,6 +395,10 @@ static PyObject *test_raw_realloc_zerosize(PyObject *mod, PyObject *args) {
 	Py_RETURN_NONE;
 }
 
+static PyObject *test_unreachable(PyObject *mod) {
+    Py_UNREACHABLE();
+}
+
 #define FUNC(style, name) { #name, (PyCFunction)name, style, NULL }
 
 static PyMethodDef methods[] = {
@@ -428,6 +432,7 @@ static PyMethodDef methods[] = {
     FUNC(METH_O, float_fromstring),
 
 	FUNC(METH_NOARGS, return_notimplemented),
+	FUNC(METH_NOARGS, test_unreachable),
 
 	FUNC(METH_NOARGS, capsule_get_count),
 	FUNC(METH_NOARGS, capsule_new),

--- a/test/test_py3c.c
+++ b/test/test_py3c.c
@@ -20,7 +20,8 @@ static PyObject *str_checkexact(PyObject *mod, PyObject * o) {
 	return PyBool_FromLong(PyStr_CheckExact(o));
 }
 
-static PyObject *str_fromstring(PyObject *mod) {
+/* Note: this also tests that Py_UNUSED works */
+static PyObject *str_fromstring(PyObject *mod, PyObject *Py_UNUSED(o)) {
 	return PyStr_FromString(UTF8_STRING);
 }
 
@@ -404,7 +405,7 @@ static PyObject *test_unreachable(PyObject *mod) {
 static PyMethodDef methods[] = {
 	FUNC(METH_O, str_check),
 	FUNC(METH_O, str_checkexact),
-	FUNC(METH_NOARGS, str_fromstring),
+	FUNC(METH_VARARGS, str_fromstring),
 	FUNC(METH_O, str_fromstringandsize),
 	FUNC(METH_NOARGS, str_fromformat),
 	FUNC(METH_NOARGS, str_fromformatv),


### PR DESCRIPTION
Python 3.7 will finally include a rich comparison helper, so we can deprecate `PY3C_RICHCMP`.

Fixes https://github.com/encukou/py3c/issues/15
