### PR TITLE
Add unused attribute to PyStr_Concat if compiling with gcc

### DIFF
--- a/include/py3c/compat.h
+++ b/include/py3c/compat.h
@@ -73,6 +73,9 @@
 #define PyStr_InternFromString PyString_InternFromString
 #define PyStr_Decode PyString_Decode
 
+#ifdef __GNUC__
+static PyObject *PyStr_Concat(PyObject *left, PyObject *right) __attribute__ ((unused));
+#endif
 static PyObject *PyStr_Concat(PyObject *left, PyObject *right) {
     PyObject *str = left;
     Py_INCREF(left);  // reference to old left will be stolen


### PR DESCRIPTION
This supresses harmless compilation warnings that the
function is unused.