### PR TITLE
Have Travis CI fail on compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ python:
   - "nightly"
 
 env:
-  - TEST_USE_CPP=no
-  - TEST_USE_CPP=yes
+    - TEST_USE_CPP=no
+      CFLAGS="-Werror -Wall -std=c90 -Wno-error=strict-aliasing"
+    - TEST_USE_CPP=yes
+      CFLAGS="-Werror -Wall -Wno-error=strict-aliasing"
 
 script: make test-python
 

--- a/include/py3c/compat.h
+++ b/include/py3c/compat.h
@@ -28,7 +28,7 @@
 #define PyStr_InternFromString PyUnicode_InternFromString
 #define PyStr_Decode PyUnicode_Decode
 
-#define PyStr_AsUTF8String PyUnicode_AsUTF8String // returns PyBytes
+#define PyStr_AsUTF8String PyUnicode_AsUTF8String /* returns PyBytes */
 #define PyStr_AsUTF8 PyUnicode_AsUTF8
 #define PyStr_AsUTF8AndSize PyUnicode_AsUTF8AndSize
 
@@ -78,7 +78,7 @@ static PyObject *PyStr_Concat(PyObject *left, PyObject *right) __attribute__ ((u
 #endif
 static PyObject *PyStr_Concat(PyObject *left, PyObject *right) {
     PyObject *str = left;
-    Py_INCREF(left);  // reference to old left will be stolen
+    Py_INCREF(left);  /* reference to old left will be stolen */
     PyString_Concat(&str, right);
     if (str) {
         return str;

--- a/test/test_py3c.c
+++ b/test/test_py3c.c
@@ -468,8 +468,9 @@ static PyMethodDef methods[] = {
 	{ NULL }
 };
 
-// C++ apparently doesn't allow forward declarations for data
-// http://stackoverflow.com/a/936589/99057
+/* C++ apparently doesn't allow forward declarations for data
+ * http://stackoverflow.com/a/936589/99057
+ */
 #ifdef __cplusplus
 #define FORWARD_TYPE extern
 #else


### PR DESCRIPTION
Also, change C++-style comments to old-style C ones, so the corresponding warnings aren't triggered.