### PR TITLE
Add `PyLong_AS_LONG`

### DIFF
--- a/include/py3c/compat.h
+++ b/include/py3c/compat.h
@@ -112,6 +112,9 @@ static PyObject *PyStr_Concat(PyObject *left, PyObject *right) {
 
 #define PyFloat_FromString(str) PyFloat_FromString(str, NULL)
 
+/* Longs */
+#define PyLong_AS_LONG PyInt_AS_LONG
+
 /* Module init */
 
 #define PyModuleDef_HEAD_INIT 0


### PR DESCRIPTION
`PyLong_AS_LONG` isn't present in longobject.h on python 2.x. Add it
to workaround the shortcoming with affected releases and to enable
forward compatible (3.x) idioms in python 2.x.

See also: https://bugs.python.org/issue39762

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>