### PR TITLE
Add DESTDIR for staged installations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,12 @@ py3c.pc: py3c.pc.in $(includedir)
 	sed -e's:@includedir@:$(realpath $(includedir)):' $< > $@
 
 install: py3c.pc
-	mkdir -p -m 0755 $(includedir)/py3c
-	install -m 0644 include/py3c.h $(includedir)/py3c.h
-	install -m 0644 $(wildcard include/py3c/*.h) $(includedir)/py3c/
+	mkdir -p -m 0755 $(DESTDIR)$(includedir)/py3c
+	install -m 0644 include/py3c.h $(DESTDIR)$(includedir)/py3c.h
+	install -m 0644 $(wildcard include/py3c/*.h) $(DESTDIR)$(includedir)/py3c/
 
-	mkdir -p -m 0755 $(pkgconfigdir)
-	install -m 0644 py3c.pc $(pkgconfigdir)/
+	mkdir -p -m 0755 $(DESTDIR)$(pkgconfigdir)
+	install -m 0644 py3c.pc $(DESTDIR)$(pkgconfigdir)/
 
 clean:
 	rm py3c.pc ||:


### PR DESCRIPTION
This is something we use in the [OpenBSD ports tree](https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/devel/py3c/patches/patch-Makefile?rev=1.1.1.1&content-type=text/plain) but could benefit all downstreams. 

For reference: https://www.gnu.org/prep/standards/html_node/DESTDIR.html