### PR TITLE
Align PyModuleDef with Python 3, fixes encukou/py3c#34

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -14,6 +14,14 @@ Compatibility:
 
 * Tested with Python 3.9.0
 
+Additions:
+
+* To help avoid compiler warning about uninitialized members, extra members
+  are added to the ``PyModuleDef`` structure for Python 2: ``m_slots``,
+  ``m_traverse``, ``m_clear`` and ``m_free``.
+  Under Python 2, they must be set to NULL (usually by continuing to leave
+  them out).
+
 
 v1.2 (2020-06-27)
 -----------------

--- a/doc/source/defs.rst
+++ b/doc/source/defs.rst
@@ -61,6 +61,8 @@ The following non-trivial macros are defined:
 
     :c:type:`PyModuleDef`
         | Python 2: contains ``m_name``, ``m_doc``, ``m_size``, ``m_methods`` fields from Python 3, and ``m_base`` to accomodate PyModuleDef_HEAD_INIT.
+        Also contains members `m_slots`, `m_traverse`, `m_clear`, `m_free`,
+        which must be set to NULL.
 
     :c:func:`PyModule_Create`
         | Python 2: calls Py_InitModule3; semantics same as in Python 3

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -430,13 +430,29 @@ Module Initialization
 
         .. c:member:: char *m_name
 
+            Name of the new module
+
         .. c:member:: char *m_doc
+
+            Documentation string, or NULL
 
         .. c:member:: Py_ssize_t m_size
 
             Set this to -1. (Or if your module supports :c:func:`subinterpreters <py3:Py_NewInterpreter>`, use 0)
 
         .. c:member:: PyMethodDef m_methods
+
+            Pointer to a table of module-level functions
+
+        Four more members are provided.
+        Under Python 2, set them to NULL.
+        (In a global ``static`` structure, you can leave them out
+        unless you want to avoid warnings about unitialized members):
+
+            .. c:member:: m_slots
+            .. c:member:: m_traverse
+            .. c:member:: m_clear
+            .. c:member:: m_free
 
     Python 3: :c:type:`(provided) <py3:PyModuleDef>`
 

--- a/include/py3c/compat.h
+++ b/include/py3c/compat.h
@@ -5,6 +5,7 @@
 #ifndef _PY3C_COMPAT_H_
 #define _PY3C_COMPAT_H_
 #include <Python.h>
+#include <assert.h>
 
 #if PY_MAJOR_VERSION >= 3
 
@@ -128,8 +129,13 @@ typedef struct PyModuleDef {
     void* m_free;
 } PyModuleDef;
 
-#define PyModule_Create(def) \
-    Py_InitModule3((def)->m_name, (def)->m_methods, (def)->m_doc)
+static PyObject *PyModule_Create(PyModuleDef *def) {
+    assert(!def->m_slots);
+    assert(!def->m_traverse);
+    assert(!def->m_clear);
+    assert(!def->m_free);
+    return Py_InitModule3(def->m_name, def->m_methods, def->m_doc);
+}
 
 #define MODULE_INIT_FUNC(name) \
     static PyObject *PyInit_ ## name(void); \

--- a/include/py3c/compat.h
+++ b/include/py3c/compat.h
@@ -122,6 +122,10 @@ typedef struct PyModuleDef {
     const char* m_doc;
     Py_ssize_t m_size;
     PyMethodDef *m_methods;
+    void* m_slots;
+    void* m_traverse;
+    void* m_clear;
+    void* m_free;
 } PyModuleDef;
 
 #define PyModule_Create(def) \


### PR DESCRIPTION
By extending the `PyModuleDef` struct for Python 2 with the fields present in Python 3, client code can provide field initializers to avoid the `-Wmissing-field-initializers` compiler warning.