### PR TITLE
Allow to build the docs without RTD theme

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -106,9 +106,8 @@ html_theme = 'default'
 if not os.environ.get('READTHEDOCS', None):
     try:
         import sphinx_rtd_theme
-    except ():#ImportError:
+    except ImportError:
         pass
-        1/0
     else:
         html_theme = 'sphinx_rtd_theme'
         html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]


### PR DESCRIPTION
I don't really understand the `1/0` bit, but I suppose it is a debugging leftover.

Anyway. In RHEL 9, py3c-doc is the only package that seem to require sphinx_rtd_theme on runtime. This should allow us to not use it there.

https://tiny.distro.builders/view-rpm--view-eln--python3-sphinx_rtd_theme.html