### PR TITLE
Avoid GCC warnings on unused functions

### DIFF
--- a/include/py3c/compat.h
+++ b/include/py3c/compat.h
@@ -129,6 +129,9 @@ typedef struct PyModuleDef {
     void* m_free;
 } PyModuleDef;
 
+#ifdef __GNUC__
+static PyObject *PyModule_Create(PyModuleDef *def) __attribute__ ((unused));
+#endif
 static PyObject *PyModule_Create(PyModuleDef *def) {
     assert(!def->m_slots);
     assert(!def->m_traverse);

--- a/include/py3c/compat.h
+++ b/include/py3c/compat.h
@@ -7,6 +7,18 @@
 #include <Python.h>
 #include <assert.h>
 
+/* Mark a function as `static inline`.
+ * Before C99, `inline` is not available, so use just `static` and silence
+ * "unused definition" warnings on some compilers.
+ */
+#if __STDC_VERSION__ >= 199901L
+#define _py3c_STATIC_INLINE_FUNCTION(d) static inline d
+#elif defined(__GNUC__) || defined(__clang__)
+#define _py3c_STATIC_INLINE_FUNCTION(d) static d __attribute__ ((unused)); static d
+#else
+#define _py3c_STATIC_INLINE_FUNCTION(d) static d
+#endif
+
 #if PY_MAJOR_VERSION >= 3
 
 /***** Python 3 *****/
@@ -74,10 +86,7 @@
 #define PyStr_InternFromString PyString_InternFromString
 #define PyStr_Decode PyString_Decode
 
-#ifdef __GNUC__
-static PyObject *PyStr_Concat(PyObject *left, PyObject *right) __attribute__ ((unused));
-#endif
-static PyObject *PyStr_Concat(PyObject *left, PyObject *right) {
+_py3c_STATIC_INLINE_FUNCTION(PyObject *PyStr_Concat(PyObject *left, PyObject *right)) {
     PyObject *str = left;
     Py_INCREF(left);  /* reference to old left will be stolen */
     PyString_Concat(&str, right);
@@ -129,10 +138,7 @@ typedef struct PyModuleDef {
     void* m_free;
 } PyModuleDef;
 
-#ifdef __GNUC__
-static PyObject *PyModule_Create(PyModuleDef *def) __attribute__ ((unused));
-#endif
-static PyObject *PyModule_Create(PyModuleDef *def) {
+_py3c_STATIC_INLINE_FUNCTION(PyObject *PyModule_Create(PyModuleDef *def)) {
     assert(!def->m_slots);
     assert(!def->m_traverse);
     assert(!def->m_clear);

--- a/include/py3c/fileshim.h
+++ b/include/py3c/fileshim.h
@@ -21,6 +21,10 @@ Caveats:
 static char FLUSH[] = "flush";
 static char EMPTY_STRING[] = "";
 
+#ifdef __GNUC__
+static FILE* py3c_PyFile_AsFileWithMode(PyObject *py_file, const char *mode) __attribute__ ((unused));
+#endif
+
 static FILE* py3c_PyFile_AsFileWithMode(PyObject *py_file, const char *mode) {
     FILE *f;
     PyObject *ret;

--- a/include/py3c/fileshim.h
+++ b/include/py3c/fileshim.h
@@ -5,6 +5,7 @@
 #ifndef _PY3C_FILESHIM_H_
 #define _PY3C_FILESHIM_H_
 #include <Python.h>
+#include <py3c/compat.h>
 
 /*
 
@@ -21,11 +22,7 @@ Caveats:
 static char FLUSH[] = "flush";
 static char EMPTY_STRING[] = "";
 
-#ifdef __GNUC__
-static FILE* py3c_PyFile_AsFileWithMode(PyObject *py_file, const char *mode) __attribute__ ((unused));
-#endif
-
-static FILE* py3c_PyFile_AsFileWithMode(PyObject *py_file, const char *mode) {
+_py3c_STATIC_INLINE_FUNCTION(FILE* py3c_PyFile_AsFileWithMode(PyObject *py_file, const char *mode)) {
     FILE *f;
     PyObject *ret;
     int fd;

--- a/test/all_py3c_headers.h
+++ b/test/all_py3c_headers.h
@@ -1,0 +1,7 @@
+/* Include all py3c headers, including optional ones */
+
+#include <Python.h>
+#include <py3c.h>
+#include <py3c/capsulethunk.h>
+#include <py3c/fileshim.h>
+#include <py3c/tpflags.h>

--- a/test/setup.py
+++ b/test/setup.py
@@ -9,9 +9,9 @@ USE_CPP = (os.environ.get('TEST_USE_CPP') == 'yes')
 # (there's also a gcc -x switch, but it needs to go before the filename;
 # I don't think setuptools allows that)
 if USE_CPP:
-    sources = ['test_py3c.cpp']
+    sources = ['test_py3c.cpp', 'test_empty.cpp']
 else:
-    sources = ['test_py3c.c']
+    sources = ['test_py3c.c', 'test_empty.c']
 
 extra_compile_args = []
 extra_compile_args.extend(['-Werror', '-Wall'])

--- a/test/test_empty.c
+++ b/test/test_empty.c
@@ -1,0 +1,5 @@
+/* This file includes all py3c headers, but doesn't use anything.
+ * This file exists to ensure we don't get any warnings about unused items.
+ */
+
+#include "all_py3c_headers.h"

--- a/test/test_empty.cpp
+++ b/test/test_empty.cpp
@@ -1,0 +1,1 @@
+test_empty.c

--- a/test/test_py3c.c
+++ b/test/test_py3c.c
@@ -1,12 +1,8 @@
 /* Make sure Py_UNREACHABLE errors out */
 #define RANDALL_WAS_HERE
 
-#include <Python.h>
+#include "all_py3c_headers.h"
 #include "structmember.h"
-#include <py3c.h>
-#include <py3c/capsulethunk.h>
-#include <py3c/fileshim.h>
-#include <py3c/tpflags.h>
 
 #define UTF8_STRING "test string \xe1\xba\x87\xc3\xad\xc5\xa5\xc4\xa7 \xc5\xae\xc5\xa2\xe1\xb8\x9e\xe2\x88\x9e \xe2\x98\xba"
 #define FORMAT_STRING "<%s:%d>"

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,5 @@ setenv=
     c99: CFLAGS=-Werror -Wall -std=c99 -Wno-error=strict-aliasing
     cpp: TEST_USE_CPP=yes
     cpp: CFLAGS=-Werror -Wall -Wno-error=strict-aliasing
+    clang: CC=clang
+    clang: CFLAGS=-Werror -Wall -std=c99


### PR DESCRIPTION
Fixes: https://github.com/encukou/py3c/issues/40 (for GCC)

Making the functions `inline` would be better here, but `inline` is
not available in C90.

Includes tests to avoid future regressions.