### PR TITLE
Forward PyFile_FromFile to PyFile_FromFd, fixes encukou#44

### DIFF
--- a/include/py3c/compat.h
+++ b/include/py3c/compat.h
@@ -56,7 +56,7 @@
 /* Files */
 
 #define PyFile_FromFile(fp, name, mode, close) \
-    PyFile_FromFd(fileno(fp), name, mode, -1, NULL, NULL, NULL, close ? 1 : 0)
+    PyFile_FromFd(fileno(fp), name, mode, -1, NULL, NULL, NULL, close == fclose ? 1 : 0)
 
 #else
 

--- a/include/py3c/compat.h
+++ b/include/py3c/compat.h
@@ -53,6 +53,11 @@
     PyMODINIT_FUNC PyInit_ ## name(void); \
     PyMODINIT_FUNC PyInit_ ## name(void)
 
+/* Files */
+
+#define PyFile_FromFile(fp, name, mode, close) \
+    PyFile_FromFd(fileno(fp), name, mode, -1, NULL, NULL, NULL, close ? 1 : 0)
+
 #else
 
 /***** Python 2 *****/


### PR DESCRIPTION
In Python 2 there is only PyFile_FromFile that takes a file pointer whereas in Python 3 there is only PyFile_FromFd that takes a file descriptor. With the help of fileno() from stdio.h we can convert the file pointer to a descriptor.