### PR TITLE
Makefile: fix DESTDIR support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,8 @@ test-%: build-%
 test-%-cpp: build-%-cpp
 	TEST_USE_CPP=yes PYTHONPATH=$(wildcard ${_testbuilddir_abs}/lib*) $* test -v
 
-$(includedir):
-	mkdir -p $(includedir)
-
-py3c.pc: py3c.pc.in $(includedir)
-	sed -e's:@includedir@:$(realpath $(includedir)):' $< > $@
+py3c.pc: py3c.pc.in
+	sed -e's:@includedir@:$(abspath $(includedir)):' $< > $@
 
 install: py3c.pc
 	mkdir -p -m 0755 $(DESTDIR)$(includedir)/py3c


### PR DESCRIPTION
The makefile will fail if ran as:

    make DESTDIR=/tmp/stage prefix=/opt/this/does/not/exist install

The reason is that the Makefile runs "realpath" on the calculated
$(prefix)/include directory, but this will return an empty string
when the path does not yet exist, leading to a broken py3c.pc
pkg-config file.

Furthermore, we were trying to do "mkdir -p $(includedir)"
which simply cannot work when the install prefix is read-only,
for example when creating RPMs or preparing packages where
the final prefix is not writeable by the build process.

Fix these issues by using abspath on the specified $(includedir) and
and removing the mkdir handling.

The "install" target already handles prefixing paths with $(DESTDIR)
so this is the last missing piece towards making it work robustly
in typical situations.

Signed-off-by: David Aguilar <davvid@gmail.com>